### PR TITLE
Add patch to fix building on MinGW/GCC8

### DIFF
--- a/424f64f27d94f83ed946ebfcf9b9543c828f9f25.patch
+++ b/424f64f27d94f83ed946ebfcf9b9543c828f9f25.patch
@@ -1,0 +1,27 @@
+From 424f64f27d94f83ed946ebfcf9b9543c828f9f25 Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Sun, 27 May 2018 22:56:05 +0200
+Subject: [PATCH] Fix invalid cast in wxMSW AutoHANDLE::InvalidHandle()
+
+Somehow this compiled with the previous gcc versions (as well as MSVS),
+but a static_cast from an integer wxUIntPtr type to a pointer HANDLE
+type is obviously invalid and a reinterpret_cast is needed here.
+
+This fixes compilation with g++ 8.
+---
+ include/wx/msw/private.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/wx/msw/private.h b/include/wx/msw/private.h
+index f833a58a0f0..1e4d0f8fcd8 100644
+--- a/include/wx/msw/private.h
++++ b/include/wx/msw/private.h
+@@ -145,7 +145,7 @@ class AutoHANDLE
+     // implicitly convertible to HANDLE, which is a pointer.
+     static HANDLE InvalidHandle()
+     {
+-        return static_cast<HANDLE>(INVALID_VALUE);
++        return reinterpret_cast<HANDLE>(INVALID_VALUE);
+     }
+ 
+     void DoClose()

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class wxWidgetsConan(ConanFile):
     homepage = "https://www.wxwidgets.org/"
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "wxWidgets"
-    exports = ["LICENSE.md"]
+    exports = ["LICENSE.md", "*.patch"]
     exports_sources = ["CMakeLists.txt"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
@@ -126,6 +126,7 @@ class wxWidgetsConan(ConanFile):
         tools.get("{0}/archive/v{1}.tar.gz".format(source_url, self.version))
         extracted_dir = "wxWidgets-" + self.version
         os.rename(extracted_dir, self.source_subfolder)
+        tools.patch(self.source_subfolder, "424f64f27d94f83ed946ebfcf9b9543c828f9f25.patch")
 
     def add_libraries_from_pc(self, library):
         pkg_config = tools.PkgConfig(library)

--- a/conanfile.py
+++ b/conanfile.py
@@ -119,7 +119,7 @@ class wxWidgetsConan(ConanFile):
         if self.options.zlib == 'zlib':
             self.requires.add('zlib/1.2.11@conan/stable')
         if self.options.expat == 'expat':
-            self.requires.add('expat/2.2.5@bincrafters/stable')
+            self.requires.add('Expat/2.2.6@pix4d/stable')
 
     def source(self):
         source_url = "https://github.com/wxWidgets/wxWidgets"


### PR DESCRIPTION
Add the following patch to fix building on MinGW/GCC8:
https://github.com/wxWidgets/wxWidgets/commit/424f64f27d94f83ed946ebfcf9b9543c828f9f25.patch

Note that the patch alone is not enough to easily use the package with mingw and cmake, I also had to fix linked library names to force linking by file name, using the `-l:not_lib_prefixed.a` syntax
```
# cleanup wx libs in CMake
set(CONAN_LIBS_FIXED ${CONAN_LIBS})
foreach(lib ${CONAN_LIBS_WXWIDGETS})
	if(lib MATCHES "^wx")
		list(TRANSFORM CONAN_LIBS_FIXED REPLACE "^${lib}$" ":${lib}.a")
	endif()
endforeach()

target_link_libraries(wxApp PUBLIC ${CONAN_LIBS_FIXED})
```