### PR TITLE
Fix unresolved reference error when using STC

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -256,6 +256,9 @@ class wxWidgetsConan(ConanFile):
         if self.options.richtext:
             libs.append(library_pattern('richtext'))
         if self.options.stc:
+            if not self.options.shared:
+                scintilla_suffix = '{debug}' if self.settings.os == "Windows" else '{suffix}'
+                libs.append('wxscintilla' + scintilla_suffix)
             libs.append(library_pattern('stc'))
         if self.options.webview:
             libs.append(library_pattern('webview'))

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -2,6 +2,9 @@
 #include <iostream>
 #include <wx/utils.h>
 #include <wx/init.h>
+#if wxUSE_STC
+#include <wx/stc/stc.h>
+#endif
 
 int main()
 {
@@ -16,6 +19,9 @@ int main()
     std::cout << vi.GetMajor() << ".";
     std::cout << vi.GetMinor() << ".";
     std::cout << vi.GetMicro() << std::endl;
+#if wxUSE_STC
+    wxStyledTextCtrl * stc = new wxStyledTextCtrl();
+#endif
     wxEntryCleanup();
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When the stc option is True and the shared option is False, unresolved reference error occurs.

i.e.
> arch=x86_64
    build_type=Release
    compiler=Visual Studio
    compiler.runtime=MD
    compiler.version=15
    os=Windows
    shared=False
    stc=True

When using wxStyledTextCtrl like this:
`wxStyledTextCtrl * stc = new wxStyledTextCtrl();` 
we need to link `wxscintilla.lib`.