### PR TITLE
Update Expat to version 2.2.7

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -138,7 +138,7 @@ class wxWidgetsConan(ConanFile):
         if self.options.zlib == 'zlib':
             self.requires.add('zlib/1.2.11@conan/stable')
         if self.options.expat == 'expat':
-            self.requires.add('Expat/2.2.6@pix4d/stable')
+            self.requires.add('Expat/2.2.7@pix4d/stable')
 
     def source(self):
         source_url = "https://github.com/wxWidgets/wxWidgets"


### PR DESCRIPTION
Build is broken because 2.2.6 is no longer available.