### PR TITLE
add more options to solve dependency problems

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,6 @@ jobs:
       Gcc 8:
         CONAN_GCC_VERSIONS: 8
         CONAN_DOCKER_IMAGE: conanio/gcc8
-      Gcc 9:
-        CONAN_GCC_VERSIONS: 9
-        CONAN_DOCKER_IMAGE: conanio/gcc9
       Clang 3.9:
         CONAN_CLANG_VERSIONS: 3.9
         CONAN_DOCKER_IMAGE: conanio/clang39
@@ -55,6 +52,3 @@ jobs:
       Clang 7.0:
         CONAN_CLANG_VERSIONS: 7.0
         CONAN_DOCKER_IMAGE: conanio/clang7
-      Clang 8:
-        CONAN_CLANG_VERSIONS: 8
-        CONAN_DOCKER_IMAGE: conanio/clang8

--- a/conanfile.py
+++ b/conanfile.py
@@ -13,7 +13,7 @@ class wxWidgetsConan(ConanFile):
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "wxWidgets"
     exports = ["LICENSE.md", "*.patch"]
-    exports_sources = ["CMakeLists.txt"]
+    exports_sources = ["CMakeLists.txt", "modules/FindEXPAT.cmake"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
 
@@ -226,6 +226,8 @@ class wxWidgetsConan(ConanFile):
         for item in str(self.options.custom_disables).split(","):
             if len(item) > 0:
                 cmake.definitions[item] = False
+
+        cmake.definitions['CMAKE_MODULE_PATH'] = os.path.abspath('modules').replace('\\', '/')
 
         cmake.configure(build_folder=self._build_subfolder)
         return cmake

--- a/modules/FindEXPAT.cmake
+++ b/modules/FindEXPAT.cmake
@@ -1,0 +1,89 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindEXPAT
+---------
+
+Find the native Expat headers and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets:
+
+``EXPAT::EXPAT``
+  The Expat ``expat`` library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``EXPAT_INCLUDE_DIRS``
+  where to find expat.h, etc.
+``EXPAT_LIBRARIES``
+  the libraries to link against to use Expat.
+``EXPAT_FOUND``
+  true if the Expat headers and libraries were found.
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+
+pkg_check_modules(PC_EXPAT QUIET expat)
+
+# Look for the header file.
+find_path(EXPAT_INCLUDE_DIR NAMES expat.h HINTS ${PC_EXPAT_INCLUDE_DIRS})
+
+# Look for the library.
+# ------------------------------------------------------------
+# ------------------     MODIFIED START      -----------------
+# ------------------------------------------------------------
+find_library(EXPAT_LIBRARY NAMES expat libexpat HINTS ${PC_EXPAT_LIBRARY_DIRS})
+if(EXPAT_LIBRARY STREQUAL "EXPAT_LIBRARY-NOTFOUND")
+    find_library(EXPAT_LIBRARY NAMES expatd HINTS ${PC_EXPAT_LIBRARY_DIRS})
+endif()
+# ------------------------------------------------------------
+# ------------------      MODIFIED END       -----------------
+# ------------------------------------------------------------
+
+if (EXPAT_INCLUDE_DIR AND EXISTS "${EXPAT_INCLUDE_DIR}/expat.h")
+    file(STRINGS "${EXPAT_INCLUDE_DIR}/expat.h" expat_version_str
+         REGEX "^#[\t ]*define[\t ]+XML_(MAJOR|MINOR|MICRO)_VERSION[\t ]+[0-9]+$")
+
+    unset(EXPAT_VERSION_STRING)
+    foreach(VPART MAJOR MINOR MICRO)
+        foreach(VLINE ${expat_version_str})
+            if(VLINE MATCHES "^#[\t ]*define[\t ]+XML_${VPART}_VERSION[\t ]+([0-9]+)$")
+                set(EXPAT_VERSION_PART "${CMAKE_MATCH_1}")
+                if(EXPAT_VERSION_STRING)
+                    string(APPEND EXPAT_VERSION_STRING ".${EXPAT_VERSION_PART}")
+                else()
+                    set(EXPAT_VERSION_STRING "${EXPAT_VERSION_PART}")
+                endif()
+            endif()
+        endforeach()
+    endforeach()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EXPAT
+                                  REQUIRED_VARS EXPAT_LIBRARY EXPAT_INCLUDE_DIR
+                                  VERSION_VAR EXPAT_VERSION_STRING)
+
+# Copy the results to the output variables and target.
+if(EXPAT_FOUND)
+  set(EXPAT_LIBRARIES ${EXPAT_LIBRARY})
+  set(EXPAT_INCLUDE_DIRS ${EXPAT_INCLUDE_DIR})
+
+  if(NOT TARGET EXPAT::EXPAT)
+    add_library(EXPAT::EXPAT UNKNOWN IMPORTED)
+    set_target_properties(EXPAT::EXPAT PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${EXPAT_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${EXPAT_INCLUDE_DIRS}")
+  endif()
+endif()
+
+mark_as_advanced(EXPAT_INCLUDE_DIR EXPAT_LIBRARY)


### PR DESCRIPTION
Added:
```
               "cairo": True,
               "help": True,
               "html_help": True,
               "url": True,
               "protocol": True,
               "fs_inet": False,
               "custom_enables": "",
               "custom_disables": ""
```

If we don't have those options, build will fail if `sockets` is `False`:

```
C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\3fe30dbec7795a5650d435224989b3b7f2ca4d59\source_subfolder\include\wx/chkconf.h(1350): fatal error C1189: #error:  "wxUSE_PROTOCOL_FTP/HTTP requires wxUSE_SOCKETS" (编译源文件 C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\3fe30dbec7795a5650d435224989b3b7f2ca4d59\source_subfolder\src\regex\regerror.c) [C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\3fe30dbec7795a5650d435224989b3b7f2ca4d59\build_subfolder\source_subfolder\libs\wxregex.vcxproj]

C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\4ed1aed1db0d6a6368243b48dfc7bf3a81c075f0\source_subfolder\include\wx/chkconf.h(1912): fatal error C1189: #error:  "Built in help controller can't be compiled" (编译源文件 C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\4ed1aed1db0d6a6368243b48dfc7bf3a81c075f0\source_subfolder\src\regex\regexec.c) [C:\Users\cqjjj\.conan\data\wxwidgets\3.1.2\bincrafters\stable\build\4ed1aed1db0d6a6368243b48dfc7bf3a81c075f0\build_subfolder\source_subfolder\libs\wxregex.vcxproj]
```